### PR TITLE
Allow using GP with IPv6 enabled

### DIFF
--- a/6/DockerFile
+++ b/6/DockerFile
@@ -140,6 +140,7 @@ RUN su - gpadmin bash -c '\
     echo "gpinitsystem ..." && \
     gpinitsystem --ignore-warnings -ac gpinitsystem_singlenode && \
     echo "host all  all 0.0.0.0/0 trust" >> /data/master/gpsne-1/pg_hba.conf && \
+    echo "host all  all ::0/0 trust" >> /data/master/gpsne-1/pg_hba.conf && \
     psql -d postgres -c "alter role gpadmin with password \$\$123456\$\$" && \
     echo "gpstop ..." && \
     gpstop -a'

--- a/6/DockerFile
+++ b/6/DockerFile
@@ -4,7 +4,7 @@ SHELL ["/bin/bash", "-c"]
 RUN echo 'alias ll="ls -l"' >> /root/.bashrc
 RUN echo 'export PS1="\[\033[1;36m\][\u@\h \W]\[\033[0;31m\]$\[\033[0;37m\] "' >> /root/.bashrc
 
-#from https://github.com/greenplum-db/gpdb/blob/6.25.3/README.ubuntu.bash:
+#from https://github.com/greenplum-db/gpdb-archive/blob/367edc6b4dfd909fe38fc288ade9e294d74e3f9a/README.ubuntu.bash:
 RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     --mount=target=/var/cache/apt,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean \
@@ -22,21 +22,22 @@ RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output /tmp/get-pip.py &
 RUN pip2.7 install PyYAML==5.3.1 conan==1.48.2 psutil==5.9.6
 RUN ln -s /usr/bin/python2.7 /usr/bin/python
 
-# Install pathed version of xerces-c https://github.com/greenplum-db/gp-xerces
+# Install pathed version of xerces-c https://github.com/greenplum-db/gp-xerces-archive
 WORKDIR /opt/
 RUN --mount=target=/opt/cache,type=cache,sharing=locked \
     cd /opt/cache && \
-    [ -f v3.1.2-p1.zip ] || wget https://github.com/greenplum-db/gp-xerces/archive/refs/tags/v3.1.2-p1.zip && \
-    unzip v3.1.2-p1.zip -d /opt/
+    [ -f gp-xerces-main.zip ] || wget https://github.com/greenplum-db/gp-xerces-archive/archive/refs/heads/main.zip -O gp-xerces-main.zip && \
+    unzip gp-xerces-main.zip -d /opt/
 
-WORKDIR /opt/gp-xerces-3.1.2-p1
+WORKDIR /opt/gp-xerces-archive-main
 RUN ./configure --prefix=/usr/local && make -j 4 && make install
 
 WORKDIR /opt/
 RUN --mount=target=/opt/cache,type=cache,sharing=locked \
     cd /opt/cache && \
-    [ -f 6.25.3.zip ] || wget https://github.com/greenplum-db/gpdb/archive/refs/tags/6.25.3.zip && \
-    unzip 6.25.3.zip -d /opt/
+    [ -f gpdb-6.25.3.zip ] || wget https://github.com/greenplum-db/gpdb-archive/archive/367edc6b4dfd909fe38fc288ade9e294d74e3f9a.zip -O gpdb-6.25.3.zip && \
+    unzip gpdb-6.25.3.zip -d /opt/ && \
+    mv /opt/gpdb-archive-367edc6b4dfd909fe38fc288ade9e294d74e3f9a /opt/gpdb-6.25.3
 
 WORKDIR /opt/gpdb-6.25.3
 RUN echo "6.25.3 build dev" > ./VERSION
@@ -110,7 +111,7 @@ RUN useradd -md /home/gpadmin/ --shell /bin/bash gpadmin \
 RUN mkdir /run/sshd
 RUN echo "set hlsearch" >> /home/gpadmin/.vimrc
 
-# from https://github.com/greenplum-db/gpdb/blob/6.21.1/src/tools/docker/ubuntu16_ppa/install_and_start_gpdb.sh:
+# from https://github.com/greenplum-db/gpdb-archive/blob/367edc6b4dfd909fe38fc288ade9e294d74e3f9a/src/tools/docker/ubuntu16_ppa/install_and_start_gpdb.sh:
 RUN su - gpadmin bash -c '\
     ssh-keygen -f /home/gpadmin/.ssh/id_rsa -t rsa -N "" && \
     cp /home/gpadmin/.ssh/id_rsa.pub /home/gpadmin/.ssh/authorized_keys && \

--- a/7/DockerFile
+++ b/7/DockerFile
@@ -4,7 +4,7 @@ SHELL ["/bin/bash", "-c"]
 RUN echo 'alias ll="ls -l"' >> /root/.bashrc
 RUN echo 'export PS1="\[\033[1;36m\][\u@\h \W]\[\033[0;31m\]$\[\033[0;37m\] "' >> /root/.bashrc
 
-#from https://github.com/greenplum-db/gpdb/blob/7.0.0/README.Ubuntu.bash:
+#from https://github.com/greenplum-db/gpdb-archive/blob/0a7a3566873325aca1789ae6f818c80f17a9402d/README.Ubuntu.bash:
 RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     --mount=target=/var/cache/apt,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean \
@@ -21,8 +21,9 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
 WORKDIR /opt/
 RUN --mount=target=/opt/cache,type=cache,sharing=locked \
     cd /opt/cache && \
-    [ -f 7.0.0.zip ] || wget https://github.com/greenplum-db/gpdb/archive/refs/tags/7.0.0.zip && \
-    unzip 7.0.0.zip -d /opt/
+    [ -f gpdb-7.0.0.zip ] || wget https://github.com/greenplum-db/gpdb-archive/archive/0a7a3566873325aca1789ae6f818c80f17a9402d.zip -O gpdb-7.0.0.zip && \
+    unzip gpdb-7.0.0.zip -d /opt/ && \
+    mv /opt/gpdb-archive-0a7a3566873325aca1789ae6f818c80f17a9402d /opt/gpdb-7.0.0
 
 WORKDIR /opt/gpdb-7.0.0/
 RUN echo "7.0.0-b2 build dev" > ./VERSION
@@ -84,7 +85,7 @@ RUN useradd -md /home/gpadmin/ --shell /bin/bash gpadmin \
 RUN mkdir /run/sshd
 RUN echo "set hlsearch" >> /home/gpadmin/.vimrc
 
-# from https://github.com/greenplum-db/gpdb/blob/6.21.1/src/tools/docker/ubuntu16_ppa/install_and_start_gpdb.sh:
+# from https://github.com/greenplum-db/gpdb-archive/blob/0a7a3566873325aca1789ae6f818c80f17a9402d/src/tools/docker/ubuntu16_ppa/install_and_start_gpdb.sh:
 RUN su - gpadmin bash -c '\
     ssh-keygen -f /home/gpadmin/.ssh/id_rsa -t rsa -N "" && \
     cp /home/gpadmin/.ssh/id_rsa.pub /home/gpadmin/.ssh/authorized_keys && \

--- a/7/DockerFile
+++ b/7/DockerFile
@@ -113,6 +113,7 @@ RUN su - gpadmin bash -c '\
     echo "gpinitsystem ..." && \
     gpinitsystem -ac gpinitsystem_singlenode && \
     echo "host all  all 0.0.0.0/0 trust" >> /data/coordinator/gpsne-1/pg_hba.conf && \
+    echo "host all  all ::0/0 trust" >> /data/coordinator/gpsne-1/pg_hba.conf && \
     psql -d postgres -c "alter role gpadmin with password \$\$123456\$\$" && \
     echo "gpstop ..." && \
     gpstop -a'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,7 +8,7 @@ su - gpadmin bash -c 'gpstart -a'
 
 trap "kill %1; su - gpadmin bash -c 'gpstop -a -M fast' && END=1" INT TERM
 
-tail -f `ls /data/master/gpsne-1/pg_log/gpdb-* | tail -n1` &
+tail -f `ls /data/{master,coordinator}/gpsne-1/{pg_log,log}/gpdb-* | tail -n1` &
 
 #trap
 while [ "$END" == '' ]; do


### PR DESCRIPTION
Latest Docker versions have IPv6 support enabled by default, which leads to errors like:
```
20240617:06:38:55:000016 gpstart:localhost:gpadmin-[CRITICAL]:-gpstart failed. (Reason='FATAL:  no pg_hba.conf entry for host "::1", user "gpadmin", database "template1" ') exiting...
```

I've updated `pg_hba.conf` to include entry `host all  all ::0/0 trust`, allowing to connect to GP from IPv6 addresses.

Unfortunately, GP main repo is archived now, and has no tags. So I've replaced them with exact commits, [source](https://git.angara.cloud/gbgreenplum/greenplum-db/gpdb). Otherwise no images can be build.

Also `7.0.0` image logs were ending with:
```
ls: cannot access '/data/master/gpsne-1/pg_log/gpdb-*': No such file or directory
```
Fixed path to log file.