### PR TITLE
Do not use trust for external connections

### DIFF
--- a/6/DockerFile
+++ b/6/DockerFile
@@ -139,8 +139,8 @@ RUN su - gpadmin bash -c '\
     gpssh-exkeys -f /data/hostlist_singlenode && \
     echo "gpinitsystem ..." && \
     gpinitsystem --ignore-warnings -ac gpinitsystem_singlenode && \
-    echo "host all  all 0.0.0.0/0 trust" >> /data/master/gpsne-1/pg_hba.conf && \
-    echo "host all  all ::0/0 trust" >> /data/master/gpsne-1/pg_hba.conf && \
+    echo "host all  all 0.0.0.0/0 md5" >> /data/master/gpsne-1/pg_hba.conf && \
+    echo "host all  all ::0/0 md5" >> /data/master/gpsne-1/pg_hba.conf && \
     psql -d postgres -c "alter role gpadmin with password \$\$123456\$\$" && \
     echo "gpstop ..." && \
     gpstop -a'

--- a/7/DockerFile
+++ b/7/DockerFile
@@ -112,8 +112,8 @@ RUN su - gpadmin bash -c '\
     gpssh-exkeys -f /data/hostlist_singlenode && \
     echo "gpinitsystem ..." && \
     gpinitsystem -ac gpinitsystem_singlenode && \
-    echo "host all  all 0.0.0.0/0 trust" >> /data/coordinator/gpsne-1/pg_hba.conf && \
-    echo "host all  all ::0/0 trust" >> /data/coordinator/gpsne-1/pg_hba.conf && \
+    echo "host all  all 0.0.0.0/0 md5" >> /data/coordinator/gpsne-1/pg_hba.conf && \
+    echo "host all  all ::0/0 md5" >> /data/coordinator/gpsne-1/pg_hba.conf && \
     psql -d postgres -c "alter role gpadmin with password \$\$123456\$\$" && \
     echo "gpstop ..." && \
     gpstop -a'

--- a/README.md
+++ b/README.md
@@ -37,3 +37,8 @@ $ docker manifest push andruche/greenplum:7.0.0
 $ docker run --name greenplum -p 5432:5432 -d andruche/greenplum:6
 $ docker run --name greenplum -p 5432:5432 -d andruche/greenplum:7
 ```
+
+You can use options below to connect to GP instance:
+* `database=postgres`
+* `user=gpadmin`
+* `password=123456`


### PR DESCRIPTION
Having pg_hba.conf entries like `all all trust` allows to connect to database without checking the password. Although this image is used only for tests, current behavior may be unexpected for ose users.

Replaced `trust` with `md5` to check password anyway. Added credentials info to README.