### PR TITLE
Run initdb.d scripts during database startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,12 @@ Difference from datagrip version:
 * Support Apple M1 processor
 * Correct stop
 * Printing greenplum logs to container logs
+* Initdb.d scripts support
 
 GPORCA optimizer temporarily disabled (some compilation problems)
 
 ## Build images
-```
+```bash
 $ docker buildx build --platform linux/arm64/v8 -f 6/DockerFile -t andruche/greenplum:6.25.3-slim-arm64 .
 $ docker push andruche/greenplum:6.25.3-slim-arm64
 $ docker buildx build --platform linux/amd64 -f 6/DockerFile -t andruche/greenplum:6.25.3-slim-amd64 .
@@ -22,7 +23,7 @@ $ docker push andruche/greenplum:7.0.0-slim-amd64
 ```
 
 ## Build manifests
-```
+```bash
 $ docker manifest rm andruche/greenplum:6.25.3
 $ docker manifest create andruche/greenplum:6.25.3 --amend andruche/greenplum:6.25.3-slim-arm64 --amend andruche/greenplum:6.25.3-slim-amd64
 $ docker manifest push andruche/greenplum:6.25.3
@@ -33,7 +34,25 @@ $ docker manifest push andruche/greenplum:7.0.0
 ```
 
 ## Usage
-```
+```bash
 $ docker run --name greenplum -p 5432:5432 -d andruche/greenplum:6
 $ docker run --name greenplum -p 5432:5432 -d andruche/greenplum:7
 ```
+
+
+## Running scripts during container startup
+
+Place `.sql` or `.sh` scripts to `./initdb.d` folder, mount it to `/container-entrypoint-initdb.d`, and then entrypoint will run these scripts
+after Greenplum was started.
+
+```sql
+-- create_user.sql
+CREATE USER myuser WITH PASSWORD 'pwd123';
+```
+
+```bash
+$ docker run --name greenplum -p 5432:5432 -v $(pwd)/initdb.d/create_user.sql:/container-entrypoint-initdb.d/create_user.sql -d andruche/greenplum:6
+$ docker run --name greenplum -p 5432:5432 -v $(pwd)/initdb.d/create_user.sql:/container-entrypoint-initdb.d/create_user.sql -d andruche/greenplum:7
+```
+
+Note: scripts will be executed on every container run, not just first run. You can manually create files in GP data folder to track if script was run before.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,15 +2,85 @@
 
 set -e
 
-/etc/init.d/ssh start
-sleep 1
-su - gpadmin bash -c 'gpstart -a'
+function run_custom_scripts {
+    SCRIPTS_ROOT="${1}";
 
-trap "kill %1; su - gpadmin bash -c 'gpstop -a -M fast' && END=1" INT TERM
+    # Check whether parameter has been passed on
+    if [ -z "${SCRIPTS_ROOT}" ]; then
+        echo "No SCRIPTS_ROOT passed on, no scripts will be run.";
+        return;
+    fi;
 
-tail -f `ls /data/{master,coordinator}/gpsne-1/{pg_log,log}/gpdb-* | tail -n1` &
+    # Execute custom provided files (only if directory exists and has files in it)
+    if [ -d "${SCRIPTS_ROOT}" ] && [ -n "$(ls -A "${SCRIPTS_ROOT}")" ]; then
+        echo -e "\nENTRYPOINT: Executing user-defined scripts..."
+        run_custom_scripts_recursive "${SCRIPTS_ROOT}"
+        echo -e "ENTRYPOINT: DONE: Executing user-defined scripts.\n"
+    fi;
+}
 
-#trap
-while [ "$END" == '' ]; do
-  sleep 1
-done
+function run_custom_scripts_recursive {
+    local f;
+    for f in "${1}"/*; do
+        case "${f}" in
+            *.sh)
+                if [ -x "${f}" ]; then
+                    echo -e "\nENTRYPOINT: running ${f} ..."; run_script_as_gpadmin "${f}"; echo "ENTRYPOINT: DONE: running ${f}"
+                else
+                    echo -e "\nENTRYPOINT: sourcing ${f} ..."; run_command_as_gpadmin "${f}" echo "ENTRYPOINT: DONE: sourcing ${f}"
+                fi;
+                ;;
+
+            *.sql)
+                echo -e "\nENTRYPOINT: running ${f} ..."; run_command_as_gpadmin psql -f "${f}"; echo "ENTRYPOINT: DONE: running ${f}"
+                ;;
+
+            *)
+                if [ -d "${f}" ]; then
+                    echo -e "\nENTRYPOINT: descending into ${f} ..."; run_custom_scripts_recursive "${f}"; echo "ENTRYPOINT: DONE: descending into ${f}"
+                else
+                    echo -e "\nENTRYPOINT: ignoring ${f}"
+                fi;
+                ;;
+        esac
+        echo "";
+    done
+}
+
+function run_script_as_gpadmin() {
+    su -w POSTGRESQL_DATABASE -w POSTGRESQL_USERNAME -w POSTGRESQL_PASSWORD - gpadmin "${1}"
+}
+
+function run_command_as_gpadmin() {
+    su -w POSTGRESQL_DATABASE -w POSTGRESQL_USERNAME -w POSTGRESQL_PASSWORD - gpadmin bash -c "${1}"
+}
+
+
+function start_gpadmin() {
+    /etc/init.d/ssh start;
+    sleep 1;
+    run_command_as_gpadmin "gpstart -a"
+}
+
+function stop_gpadmin() {
+    run_command_as_gpadmin "gpstop -a -M fast"
+}
+
+function output_logs() {
+    tail -f `ls /data/{master,coordinator}/gpsne-1/{pg_log,log}/gpdb-* | tail -n1` &
+}
+
+function main() {
+    start_gpadmin
+    trap "stop_gpadmin" INT TERM
+    output_logs
+
+    run_custom_scripts "/container-entrypoint-initdb.d"
+
+    # required by trap
+    while [ "$END" == '' ]; do
+        sleep 1
+    done
+}
+
+main


### PR DESCRIPTION
By default, this image provides only default database `postgres` with user `gpadmin` having root permissions. For tests it sometimes required to create user with minimal permissions, or create some default database objects (tables, functions, etc).

Added to entrypoint script detection if there is a directory `/container-entrypoint-initdb.d` with `*.sql` or `*.sh` files, they will be executed by `gpadmin` after GP server has been started. Example:
https://github.com/MobileTeleSystems/onetl/blob/91e72c4f6938e6ffdd8adee01f1249c932bac372/docker/greenplum/initdb.d/create_user.sh